### PR TITLE
Add partition into providerid, parse old format as well

### DIFF
--- a/pkg/controllers/instances/instances.go
+++ b/pkg/controllers/instances/instances.go
@@ -186,9 +186,18 @@ func (i *InstancesController) InstanceShutdown(ctx context.Context, node *v1.Nod
 	return false, nil
 }
 
-// InstanceMetadata returns the instance's metadata. The values returned in InstanceMetadata are
-// translated into specific fields in the Node object on registration.
-// Use the node.name or node.spec.providerID field to find the node in the cloud provider.
+// InstanceMetadata contains metadata about a specific instance.
+// Values returned in InstanceMetadata are translated into specific fields and labels for Node.
+//
+// ProviderID is a unique ID used to identify an instance on the cloud provider.
+// The ProviderID set here will be set on the node's spec.providerID field.
+// The provider ID format can be set by the cloud provider but providers should
+// ensure the format does not change in any incompatible way.
+//
+// The provider ID format used by existing cloud provider has been:
+//    <provider-name>://<instance-id>
+// Existing providers setting this field should preserve the existing format
+// currently being set in node.spec.providerID.
 func (i *InstancesController) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
 	i.logger.Printf("InstanceMetadata: node %q", node.GetName())
 	machine, err := metal.GetMachineFromNode(i.client, types.NodeName(node.Name))

--- a/pkg/controllers/instances/instances.go
+++ b/pkg/controllers/instances/instances.go
@@ -205,7 +205,7 @@ func (i *InstancesController) InstanceMetadata(ctx context.Context, node *v1.Nod
 	}
 	md := &cloudprovider.InstanceMetadata{
 		InstanceType:  *machine.Size.ID,
-		ProviderID:    fmt.Sprintf("metal://%s", *machine.ID),
+		ProviderID:    fmt.Sprintf("metal://%s/%s", *machine.Partition.ID, *machine.ID),
 		NodeAddresses: nas,
 	}
 	return md, nil

--- a/pkg/resources/metal/machine.go
+++ b/pkg/resources/metal/machine.go
@@ -72,23 +72,12 @@ func decodeMachineIDFromProviderID(providerID string) (string, error) {
 		return "", errors.New("providerID cannot be empty")
 	}
 
-	split := strings.Split(providerID, "://")
-	if len(split) != 2 {
-		return "", fmt.Errorf("unexpected providerID format %q, format should be %q", providerID, "metal://<machine-id>")
+	if !strings.HasPrefix(providerID, constants.ProviderName+"://") {
+		return "", fmt.Errorf("unexpected providerID format %q, format should be %q", providerID, constants.ProviderName+"://<machine-id>")
 	}
 
-	if split[0] != constants.ProviderName {
-		return "", fmt.Errorf("provider name from providerID %q should be metal", providerID)
-	}
-
-	idpart := split[1]
-
-	if strings.Contains(idpart, "/") {
-		idparts := strings.Split(idpart, "/")
-		return idparts[len(idparts)-1], nil
-	}
-
-	return idpart, nil
+	idparts := strings.Split(providerID, "/")
+	return idparts[len(idparts)-1], nil
 }
 
 // GetMachine returns a metal machine by its ID.

--- a/pkg/resources/metal/machine.go
+++ b/pkg/resources/metal/machine.go
@@ -73,7 +73,7 @@ func decodeMachineIDFromProviderID(providerID string) (string, error) {
 	}
 
 	if !strings.HasPrefix(providerID, constants.ProviderName+"://") {
-		return "", fmt.Errorf("unexpected providerID format %q, format should be %q", providerID, constants.ProviderName+"://<machine-id>")
+		return "", fmt.Errorf("unexpected providerID format %q, format should be %q or %q", providerID, constants.ProviderName+"://<machine-id>", constants.ProviderName+"://<partition-id>/<machine-id>")
 	}
 
 	idparts := strings.Split(providerID, "/")

--- a/pkg/resources/metal/machine.go
+++ b/pkg/resources/metal/machine.go
@@ -66,7 +66,7 @@ func GetMachineFromProviderID(client *metalgo.Driver, providerID string) (*model
 // machineIDFromProviderID returns a machine's ID from providerID.
 //
 // The providerID spec should be retrievable from the Kubernetes
-// node object. The expected format is: metal://machine-id.
+// node object. The expected format is: metal://partition-id/machine-id.
 func decodeMachineIDFromProviderID(providerID string) (string, error) {
 	if providerID == "" {
 		return "", errors.New("providerID cannot be empty")
@@ -81,7 +81,14 @@ func decodeMachineIDFromProviderID(providerID string) (string, error) {
 		return "", fmt.Errorf("provider name from providerID %q should be metal", providerID)
 	}
 
-	return split[1], nil
+	idpart := split[1]
+
+	if strings.Contains(idpart, "/") {
+		idparts := strings.Split(idpart, "/")
+		return idparts[len(idparts)-1], nil
+	}
+
+	return idpart, nil
 }
 
 // GetMachine returns a metal machine by its ID.

--- a/pkg/resources/metal/machine_test.go
+++ b/pkg/resources/metal/machine_test.go
@@ -29,6 +29,12 @@ func Test_decodeMachineIDFromProviderID(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name:       "new format with three slashes",
+			providerID: "metal:///apartition/withslashes/amachineid",
+			want:       "amachineid",
+			wantErr:    false,
+		},
+		{
 			name:       "wrong provider",
 			providerID: "aws://apartition/amachineid",
 			want:       "",

--- a/pkg/resources/metal/machine_test.go
+++ b/pkg/resources/metal/machine_test.go
@@ -8,6 +8,7 @@ func Test_decodeMachineIDFromProviderID(t *testing.T) {
 		providerID string
 		want       string
 		wantErr    bool
+		err        string
 	}{
 		{
 			name:       "old format",
@@ -32,12 +33,14 @@ func Test_decodeMachineIDFromProviderID(t *testing.T) {
 			providerID: "aws://apartition/amachineid",
 			want:       "",
 			wantErr:    true,
+			err:        "unexpected providerID format \"aws://apartition/amachineid\", format should be \"metal://<machine-id>\"",
 		},
 		{
 			name:       "wrong format",
 			providerID: "metal:/apartition/amachineid",
 			want:       "",
 			wantErr:    true,
+			err:        "unexpected providerID format \"metal:/apartition/amachineid\", format should be \"metal://<machine-id>\"",
 		},
 	}
 	for _, tt := range tests {
@@ -46,6 +49,10 @@ func Test_decodeMachineIDFromProviderID(t *testing.T) {
 			got, err := decodeMachineIDFromProviderID(tt.providerID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("decodeMachineIDFromProviderID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if (err != nil) && tt.wantErr && (err.Error() != tt.err) {
+				t.Errorf("decodeMachineIDFromProviderID() error = %v, wantErr %v", err, tt.err)
 				return
 			}
 			if got != tt.want {

--- a/pkg/resources/metal/machine_test.go
+++ b/pkg/resources/metal/machine_test.go
@@ -35,7 +35,7 @@ func Test_decodeMachineIDFromProviderID(t *testing.T) {
 		},
 		{
 			name:       "wrong format",
-			providerID: "aws:/apartition/amachineid",
+			providerID: "metal:/apartition/amachineid",
 			want:       "",
 			wantErr:    true,
 		},

--- a/pkg/resources/metal/machine_test.go
+++ b/pkg/resources/metal/machine_test.go
@@ -39,14 +39,14 @@ func Test_decodeMachineIDFromProviderID(t *testing.T) {
 			providerID: "aws://apartition/amachineid",
 			want:       "",
 			wantErr:    true,
-			err:        "unexpected providerID format \"aws://apartition/amachineid\", format should be \"metal://<machine-id>\"",
+			err:        "unexpected providerID format \"aws://apartition/amachineid\", format should be \"metal://<machine-id>\" or \"metal://<partition-id>/<machine-id>\"",
 		},
 		{
 			name:       "wrong format",
 			providerID: "metal:/apartition/amachineid",
 			want:       "",
 			wantErr:    true,
-			err:        "unexpected providerID format \"metal:/apartition/amachineid\", format should be \"metal://<machine-id>\"",
+			err:        "unexpected providerID format \"metal:/apartition/amachineid\", format should be \"metal://<machine-id>\" or \"metal://<partition-id>/<machine-id>\"",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/resources/metal/machine_test.go
+++ b/pkg/resources/metal/machine_test.go
@@ -1,0 +1,55 @@
+package metal
+
+import "testing"
+
+func Test_decodeMachineIDFromProviderID(t *testing.T) {
+	tests := []struct {
+		name       string
+		providerID string
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "old format",
+			providerID: "metal://amachineid",
+			want:       "amachineid",
+			wantErr:    false,
+		},
+		{
+			name:       "new format",
+			providerID: "metal://apartition/amachineid",
+			want:       "amachineid",
+			wantErr:    false,
+		},
+		{
+			name:       "new format",
+			providerID: "metal://apartition/withslashes/amachineid",
+			want:       "amachineid",
+			wantErr:    false,
+		},
+		{
+			name:       "wrong provider",
+			providerID: "aws://apartition/amachineid",
+			want:       "",
+			wantErr:    true,
+		},
+		{
+			name:       "wrong format",
+			providerID: "aws:/apartition/amachineid",
+			want:       "",
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodeMachineIDFromProviderID(tt.providerID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("decodeMachineIDFromProviderID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("decodeMachineIDFromProviderID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/resources/metal/machine_test.go
+++ b/pkg/resources/metal/machine_test.go
@@ -41,6 +41,7 @@ func Test_decodeMachineIDFromProviderID(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := decodeMachineIDFromProviderID(tt.providerID)
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
There are inconsistencies how we create/read the providerID

```
$ k get machine -n shoot--phjjbm--s3-test-01 shoot--phjjbm--s3-test-01-group-0-77fc5-cqh56 -o yaml|grep metal:
  providerID: metal:///fra-equ01/00000000-0000-0000-0000-ac1f6b7d7dc6

$ k get nodes shoot--phjjbm--s3-test-01-group-0-77fc5-cqh56 -o yaml|grep metal:/
  providerID: metal://00000000-0000-0000-0000-ac1f6b7d7dc6
```

On the other side:

```
rg "metal://" .
./metal-ccm/pkg/controllers/instances/instances.go
208:            ProviderID:    fmt.Sprintf("metal://%s", *machine.ID),

./metal-ccm/pkg/resources/metal/machine.go
69:// node object. The expected format is: metal://machine-id.
77:             return "", fmt.Errorf("unexpected providerID format %q, format should be %q", providerID, "metal://<machine-id>")

./machine-controller-manager-provider-metal/pkg/provider/core_util.go
39:     return fmt.Sprintf("metal:///%s/%s", partition, machineID)

./metal-stack/gardener-extension-provider-metal/pkg/controller/infrastructure/machine.go
9:      return fmt.Sprintf("metal:///%s/%s", partition, machineID)

./gardener-extension-provider-metal/pkg/controller/infrastructure/machine.go
9:      return fmt.Sprintf("metal:///%s/%s", partition, machineID)
```

Fix this in a backward compatible way.
