### PR TITLE
log if an ip is rejected

### DIFF
--- a/pkg/controllers/loadbalancer/metallb.go
+++ b/pkg/controllers/loadbalancer/metallb.go
@@ -59,6 +59,7 @@ func (cfg *MetalLBConfig) CalculateConfig(ips []*models.V1IPResponse, nws sets.S
 func (cfg *MetalLBConfig) computeAddressPools(ips []*models.V1IPResponse, nws sets.String) error {
 	for _, ip := range ips {
 		if !nws.Has(*ip.Networkid) {
+			cfg.logger.Printf("skipping ip %q: not part of cluster networks", *ip.Ipaddress)
 			continue
 		}
 		net := *ip.Networkid


### PR DESCRIPTION
At least, for now, log, if an IP address with a cluster-tag is not suitable.
In a later version, this maybe should return an error (resulting in not updating the configmap)