### PR TITLE
Only call machine/find if necessary

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -39,6 +39,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v3
       with:
+        version: v1.52.2
         args: --build-tags integration -p bugs -p unused --timeout=5m
 
     - name: Make tag

--- a/pkg/controllers/instances/instances.go
+++ b/pkg/controllers/instances/instances.go
@@ -195,7 +195,8 @@ func (i *InstancesController) InstanceShutdown(ctx context.Context, node *v1.Nod
 // currently being set in node.spec.providerID.
 func (i *InstancesController) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
 	klog.Infof("InstanceMetadata: node %q", node.GetName())
-	machine, err := i.MetalService.GetMachineFromHostname(ctx, node.Name)
+
+	machine, err := i.MetalService.GetMachineFromNode(ctx, node)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is the next optimization in order to reduce the number of machine/find requests even more.
As long as the node.spec.providerID is empty we still call machine/find, but once present we fall back to machine/get.
This should be the case after a short period of time when the machine was created, but then the providerID will always be present.