### PR TITLE
on update of a LoadBalancer service, untag old ip addresses, if any exist

### DIFF
--- a/pkg/controllers/housekeeping/loadbalancer.go
+++ b/pkg/controllers/housekeeping/loadbalancer.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	syncLoadBalancerInterval         = 1 * time.Minute
-	syncLoadBalancerMinimalInternval = 5 * time.Second
+	syncLoadBalancerInterval        = 1 * time.Minute
+	syncLoadBalancerMinimalInterval = 5 * time.Second
 )
 
 func (h *Housekeeper) startLoadBalancerConfigSynching() {
@@ -18,7 +18,7 @@ func (h *Housekeeper) startLoadBalancerConfigSynching() {
 }
 
 func (h *Housekeeper) updateLoadBalancerConfig() error {
-	if time.Since(h.lastLoadBalancerConfigSync) < syncLoadBalancerMinimalInternval {
+	if time.Since(h.lastLoadBalancerConfigSync) < syncLoadBalancerMinimalInterval {
 		return nil
 	}
 	nodes, err := kubernetes.GetNodes(context.Background(), h.k8sClient)

--- a/pkg/controllers/loadbalancer/loadbalancer.go
+++ b/pkg/controllers/loadbalancer/loadbalancer.go
@@ -107,6 +107,24 @@ func (l *LoadBalancerController) EnsureLoadBalancer(ctx context.Context, cluster
 		if err != nil {
 			return nil, err
 		}
+
+		serviceTag := tags.BuildClusterServiceFQNTag(l.clusterID, service.GetNamespace(), service.GetName())
+
+		// remove the service tag from other previous ip addresses in case the service had an ip address before
+		ips, err := l.MetalService.FindProjectIPsWithTag(ctx, l.projectID, serviceTag)
+		if err != nil {
+			return nil, err
+		}
+		for _, ip := range ips {
+			if ip.Ipaddress != nil && *ip.Ipaddress != fixedIP {
+				err = l.removeServiceTagFromIPs(ctx, serviceTag)
+				if err != nil {
+					return nil, err
+				}
+				break
+			}
+		}
+
 		newIP, err := l.useIPInCluster(ctx, *ip, l.clusterID, *service)
 		if err != nil {
 			klog.Errorf("could not associate fixed ip:%s, err: %v", fixedIP, err)
@@ -215,6 +233,20 @@ func (l *LoadBalancerController) EnsureLoadBalancerDeleted(ctx context.Context, 
 	l.ipUpdateMutex.Lock()
 	defer l.ipUpdateMutex.Unlock()
 
+	err := l.removeServiceTagFromIPs(ctx, serviceTag)
+	if err != nil {
+		return err
+	}
+
+	// we do not update the metallb config here because then the metallb controller will report a stale config
+	// this is because the service gets deleted after updating the metallb config map
+	//
+	// therefore, we let the housekeeping update the config map
+
+	return nil
+}
+
+func (l *LoadBalancerController) removeServiceTagFromIPs(ctx context.Context, serviceTag string) error {
 	ips, err := l.MetalService.FindProjectIPsWithTag(ctx, l.projectID, serviceTag)
 	if err != nil {
 		return err
@@ -254,12 +286,6 @@ func (l *LoadBalancerController) EnsureLoadBalancerDeleted(ctx context.Context, 
 			return err
 		}
 	}
-
-	// we do not update the metallb config here because then the metallb controller will report a stale config
-	// this is because the service gets deleted after updating the metallb config map
-	//
-	// therefore, we let the housekeeping update the config map
-
 	return nil
 }
 


### PR DESCRIPTION
## Description

Closes #110

