### PR TITLE
the metallb annotation actually in use is deprecated, support the new as well

### DIFF
--- a/pkg/controllers/loadbalancer/loadbalancer.go
+++ b/pkg/controllers/loadbalancer/loadbalancer.go
@@ -336,6 +336,7 @@ func (l *LoadBalancerController) useIPInCluster(ctx context.Context, ip models.V
 func (l *LoadBalancerController) acquireIP(ctx context.Context, service *v1.Service) (string, error) {
 	annotations := service.GetAnnotations()
 	addressPool, ok := annotations[constants.MetalLBSpecificAddressPool]
+	deprecatedAddressPool, deprecatedok := annotations[constants.DeprecatedMetalLBSpecificAddressPool]
 	if !ok {
 		if l.defaultExternalNetworkID == "" {
 			return "", fmt.Errorf(`no default network for ip acquisition specified, acquire an ip for your cluster's project and specify it directly in "spec.loadBalancerIP"`)

--- a/pkg/resources/constants/constants.go
+++ b/pkg/resources/constants/constants.go
@@ -18,7 +18,8 @@ const (
 	ProviderName = "metal"
 
 	// FIXME this annotation is deprecated metallb.io should be used instead
-	MetalLBSpecificAddressPool = "metallb.universe.tf/address-pool"
+	DeprecatedMetalLBSpecificAddressPool = "metallb.universe.tf/address-pool"
+	MetalLBSpecificAddressPool           = "metallb.io/address-pool"
 
 	IPPrefix = "metallb-"
 


### PR DESCRIPTION
## Description

This requires that all users also update their services type loadbalancers and migrate the existing annotation:

from:
"metallb.universe.tf/address-pool"

to:
"metallb.io/address-pool"

Once we support both.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
