### PR TITLE
fix: do not abort on tag update failure

### DIFF
--- a/pkg/controllers/housekeeping/tags.go
+++ b/pkg/controllers/housekeeping/tags.go
@@ -46,7 +46,6 @@ func (h *Housekeeper) syncMachineTagsToNodeLabels() error {
 	}
 
 	for _, n := range nodes {
-		n := n
 		nodeName := n.Name
 		tags, ok := machineTags[nodeName]
 		if !ok {
@@ -76,7 +75,8 @@ func (h *Housekeeper) syncMachineTagsToNodeLabels() error {
 
 			err = h.ms.UpdateMachineTags(m.ID, append(tags, fmt.Sprintf("%s=%s", metaltag.ClusterID, h.clusterID)))
 			if err != nil {
-				return err
+				klog.Warningf("unable to update machine tags of node %q, ignoring", n.Name)
+				continue
 			}
 			klog.Infof("added cluster tag %q to machine %q", h.clusterID, *m.ID)
 		}

--- a/pkg/controllers/housekeeping/tags.go
+++ b/pkg/controllers/housekeeping/tags.go
@@ -75,7 +75,7 @@ func (h *Housekeeper) syncMachineTagsToNodeLabels() error {
 
 			err = h.ms.UpdateMachineTags(m.ID, append(tags, fmt.Sprintf("%s=%s", metaltag.ClusterID, h.clusterID)))
 			if err != nil {
-				klog.Warningf("unable to update machine tags of node %q, ignoring", n.Name)
+				klog.Errorf("unable to update machine tags of node %q, ignoring", n.Name)
 				continue
 			}
 			klog.Infof("added cluster tag %q to machine %q", h.clusterID, *m.ID)


### PR DESCRIPTION
## Description

Early exiting the loop resulted in only trying to sync one single node when using `Metal-Edit` permissions. Here the tag update was forbidden.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
